### PR TITLE
avoid misaligned stack frame for i386-pc

### DIFF
--- a/grub-core/kern/i386/realmode.S
+++ b/grub-core/kern/i386/realmode.S
@@ -47,7 +47,21 @@
  */
 
 protstack:
-	.long	GRUB_MEMORY_MACHINE_PROT_STACK
+	/*
+	 * Note: Subtract 4 because real_to_prot/prot_to_real assume to be *called*.
+	 *       They change the address on the top of stack and then return.
+	 *
+	 *       Subsequently, for the first real_to_prot call, 'protstack' must look as if
+	 *       real_to_prot has been called - so lower the stack value by 4.
+	 *
+	 *       Otherwise, after the first real_to_prot call, the stack will have an
+	 *       invalid address of GRUB_MEMORY_MACHINE_PROT_STACK + 4.
+	 *
+	 *       Plus, this leads to breaking stack frame alignment assumptions
+	 *       in gcc (expecting stack frames to be 16-bytes aligned) and all local
+	 *       variables larger than 4 bytes will be misaligned.
+	 */
+	.long	GRUB_MEMORY_MACHINE_PROT_STACK - 4
 
 	.macro PROT_TO_REAL
 	call	prot_to_real
@@ -172,18 +186,13 @@ protcseg:
 	movw	%ax, %gs
 	movw	%ax, %ss
 
-	/* put the return address in a known safe location */
+	/* get the return address */
 	movl	(%esp), %eax
-	movl	%eax, GRUB_MEMORY_MACHINE_REAL_STACK
 
-	/* get protected mode stack */
-	movl	protstack, %eax
-	movl	%eax, %esp
-	movl	%eax, %ebp
-
-	/* get return address onto the right stack */
-	movl	GRUB_MEMORY_MACHINE_REAL_STACK, %eax
+	/* set up protected mode stack */
+	movl	protstack, %esp
 	movl	%eax, (%esp)
+	movl	%esp, %ebp
 
 	/* zero %eax */
 	xorl	%eax, %eax
@@ -222,17 +231,15 @@ prot_to_real:
 	lidt    LOCAL(realidt)
 
 	/* save the protected mode stack */
-	movl	%esp, %eax
-	movl	%eax, protstack
+	movl	%esp, protstack
 
 	/* get the return address */
 	movl	(%esp), %eax
-	movl	%eax, GRUB_MEMORY_MACHINE_REAL_STACK
 
-	/* set up new stack */
-	movl	$GRUB_MEMORY_MACHINE_REAL_STACK, %eax
-	movl	%eax, %esp
-	movl	%eax, %ebp
+	/* set up real mode stack */
+	movl	$GRUB_MEMORY_MACHINE_REAL_STACK, %esp
+	pushl	%eax
+	movl	%esp, %ebp
 
 	/* set up segment limits */
 	movw	$GRUB_MEMORY_MACHINE_PSEUDO_REAL_DSEG, %ax

--- a/grub-core/kern/main.c
+++ b/grub-core/kern/main.c
@@ -318,6 +318,8 @@ grub_main (void)
 
   grub_boot_time ("After machine init.");
 
+  STACK_ALIGN_CHECK(16);
+
   /* This breaks flicker-free boot on EFI systems, so disable it there. */
 #ifndef GRUB_MACHINE_EFI
   /* Hello.  */

--- a/include/grub/misc.h
+++ b/include/grub/misc.h
@@ -35,6 +35,20 @@
 #define ARRAY_SIZE(array) (sizeof (array) / sizeof (array[0]))
 #define COMPILE_TIME_ASSERT(cond) switch (0) { case 1: case !(cond): ; }
 
+/*
+ * gcc would optimize away the 'if' branch since it 'knows'
+ * 'x' is aligned and so the 'if' condition must be false.
+ * Pass the pointer through a volatile var to avoid this.
+ */
+#define STACK_ALIGN_CHECK(N) \
+do { \
+  int x[1] __attribute__((aligned((N)))); \
+  volatile long l = (long) x; \
+  if((l & ((N) - 1))) { \
+    grub_fatal("%s: misaligned stack: %p\n", __FUNCTION__, x); \
+  } \
+} while(0)
+
 #define grub_dprintf(condition, ...) grub_real_dprintf(GRUB_FILE, __LINE__, condition, __VA_ARGS__)
 
 void *EXPORT_FUNC(grub_memmove) (void *dest, const void *src, grub_size_t n);


### PR DESCRIPTION
The 1st real_to_prot() use prepares a misaligned protected mode stack - this leads to all local variables bigger than 32 bit to be misaligned in all grub functions.

Also, fix memory access outside the stack frame in real_to_prot() and prot_to_real() and simplify both functions.